### PR TITLE
Style modify

### DIFF
--- a/src/styles/darkmode.scss
+++ b/src/styles/darkmode.scss
@@ -769,6 +769,15 @@ $dark-red: #e21919;
     //   filter: invert(1);
     // }
   }
+
+  .subject_list {
+    li:not(.not){
+      color:$dark-text-color-bright;
+    }
+    .not{
+      color:#666;
+    }
+  }
 }
 
 .refresherDoNotColorVisited {

--- a/src/styles/darkmode.scss
+++ b/src/styles/darkmode.scss
@@ -9,6 +9,7 @@ $dark-text-color-dark: #9e9e9e;
 $dark-text-color-bright: #fff;
 $dark-text-subcolor: #777;
 $dark-text-divcolor: #444;
+$dark-text-disablecolor: #666;
 $dark-dc-color: #4987f7;
 $dark-dc-color-deep: #113475;
 $dark-highlight: #176ef1d5;
@@ -770,12 +771,20 @@ $dark-red: #e21919;
     // }
   }
 
-  .subject_list {
-    li:not(.not){
-      color:$dark-text-color-bright;
+  .write_subject{
+    .tit {
+      background: $dark-tint2;
+      color: $dark-text-color-bright;
     }
-    .not{
-      color:#666;
+
+    .subject_list {
+      li:not(.not){
+        color: $dark-text-color-bright;
+      }
+
+      .not{
+        color: $dark-text-disablecolor;
+      }
     }
   }
 }


### PR DESCRIPTION
다크모드 실행시 글작성 페이지에서 말머리 항목의 배경색일부와 글자 색상이 변경되지 않아 다음과 같은 문제가 발생합니다
- 말머리 배경색이 변경되지 않고 남아있어 다크모드의 디자인 통일성을 저하
- 각 탭의 글자색에 관련하여 활성상태가 어둡게 표시, 비활성 상태가 밝게표시 됨에 따라 활성상태에 대한 직관성이 저하

스타일 시트에 말머리 항목의 배경색 변경 및 각 말머리 탭의 활성 비활성에 따라 글자색을 변경함으로서 대응하였으니
적용을 요청합니다