### PR TITLE
Fixed vote count formatting break after vote

### DIFF
--- a/src/modules/preview.ts
+++ b/src/modules/preview.ts
@@ -1186,7 +1186,7 @@ export default {
             return false
           }
 
-          frame[type ? 'upvotes' : 'downvotes'] = res.counts
+          frame[type ? 'upvotes' : 'downvotes'] = res.counts.replace(/\B(?=(\d{3})+(?!\d))/g, ",")
 
           return true
         }


### PR DESCRIPTION
#39 
추천 버튼을 누를 시 추천수 포맷팅(세자리 단위로 쉼표)가 깨지는 문제를 해결했습니다.